### PR TITLE
Endpoints LTI - JAPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ yarn-error.log*
 .vscode
 
 # .env
+
+#specstory
+.specstory/

--- a/backend/__tests__/candidateController.test.ts
+++ b/backend/__tests__/candidateController.test.ts
@@ -1,0 +1,107 @@
+import { updateApplicationStage } from '../src/presentation/controllers/candidateController';
+
+describe('updateApplicationStage', () => {
+    let req: any;
+    let res: any;
+    let prismaMock: any;
+
+    beforeEach(() => {
+        prismaMock = {
+            interviewStep: { findUnique: jest.fn() },
+            application: { findFirst: jest.fn(), update: jest.fn() },
+        };
+        req = {
+            params: { id: '1' },
+            body: { applicationId: 2, currentInterviewStep: 3 },
+            prisma: prismaMock,
+        };
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn(),
+        };
+    });
+
+    it('actualiza exitosamente la etapa cuando la etapa y la aplicación existen', async () => {
+        // Mock: la etapa existe
+        prismaMock.interviewStep.findUnique.mockResolvedValue({ id: 3 });
+        // Mock: la aplicación existe
+        prismaMock.application.findFirst.mockResolvedValue({
+            id: 2,
+            candidateId: 1,
+            currentInterviewStep: 1,
+        });
+        // Mock: actualización exitosa
+        prismaMock.application.update.mockResolvedValue({
+            id: 2,
+            candidateId: 1,
+            currentInterviewStep: 3,
+            positionId: 5,
+        });
+
+        await updateApplicationStage(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({
+            message: 'Stage updated successfully',
+            application: {
+                id: 2,
+                candidateId: 1,
+                currentInterviewStep: 3,
+                positionId: 5,
+            },
+        });
+    });
+
+    it('devuelve 400 si la etapa (currentInterviewStep) no existe', async () => {
+        prismaMock.interviewStep.findUnique.mockResolvedValue(null);
+
+        await updateApplicationStage(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Interview step does not exist' });
+    });
+
+    it('devuelve 404 si la aplicación no existe para el candidato', async () => {
+        prismaMock.interviewStep.findUnique.mockResolvedValue({ id: 3 });
+        prismaMock.application.findFirst.mockResolvedValue(null);
+
+        await updateApplicationStage(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Application not found for this candidate' });
+    });
+
+    it('devuelve 400 si candidateId, applicationId o currentInterviewStep son inválidos', async () => {
+        req.params.id = 'abc'; // candidateId inválido
+
+        await updateApplicationStage(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Invalid candidate id, applicationId o currentInterviewStep' });
+
+        // Prueba con applicationId faltante
+        req.params.id = '1';
+        req.body.applicationId = undefined;
+
+        await updateApplicationStage(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+
+        // Prueba con currentInterviewStep faltante
+        req.body.applicationId = 2;
+        req.body.currentInterviewStep = undefined;
+
+        await updateApplicationStage(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('devuelve 500 si ocurre un error inesperado', async () => {
+        prismaMock.interviewStep.findUnique.mockRejectedValue(new Error('DB error'));
+
+        await updateApplicationStage(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Internal server error' });
+    });
+});

--- a/backend/__tests__/positionController.test.ts
+++ b/backend/__tests__/positionController.test.ts
@@ -1,0 +1,109 @@
+import { getCandidatesByPosition } from '../src/presentation/controllers/positionController';
+
+describe('getCandidatesByPosition', () => {
+    let req: any;
+    let res: any;
+    let prismaMock: any;
+
+    beforeEach(() => {
+        prismaMock = {
+            application: { findMany: jest.fn() },
+            interview: { findMany: jest.fn() },
+        };
+        req = {
+            params: { id: '1' },
+            prisma: prismaMock,
+        };
+        res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn(),
+        };
+    });
+
+    it('devuelve correctamente el array con los datos esperados cuando existen aplicaciones y entrevistas con score', async () => {
+        // Mock de aplicaciones
+        prismaMock.application.findMany.mockResolvedValue([
+            {
+                id: 1,
+                candidateId: 10,
+                currentInterviewStep: 3,
+                candidate: { id: 10, firstName: 'Juan', lastName: 'Pérez' },
+            },
+            {
+                id: 2,
+                candidateId: 11,
+                currentInterviewStep: 2,
+                candidate: { id: 11, firstName: 'Ana', lastName: 'García' },
+            },
+        ]);
+
+        // Mock de entrevistas
+        prismaMock.interview.findMany.mockResolvedValue([
+            { application: { candidateId: 10 }, score: 8 },
+            { application: { candidateId: 10 }, score: 7 },
+            { application: { candidateId: 11 }, score: 6 },
+            { application: { candidateId: 11 }, score: 8 },
+        ]);
+
+        await getCandidatesByPosition(req, res);
+
+        expect(res.json).toHaveBeenCalledWith([
+            {
+                applicationId: 1,
+                fullName: 'Juan Pérez',
+                currentInterviewStep: 3,
+                averageScore: 7.5,
+            },
+            {
+                applicationId: 2,
+                fullName: 'Ana García',
+                currentInterviewStep: 2,
+                averageScore: 7,
+            },
+        ]);
+    });
+
+    it('devuelve 404 y el mensaje correspondiente cuando no existen aplicaciones para la posición', async () => {
+        prismaMock.application.findMany.mockResolvedValue([]);
+
+        await getCandidatesByPosition(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ message: 'No applications found for this position' });
+    });
+
+    it('devuelve 400 y el mensaje correspondiente cuando el id de la posición no es numérico', async () => {
+        req.params.id = 'abc'; // id inválido
+
+        await getCandidatesByPosition(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({ message: 'Invalid position id' });
+    });
+
+    it('devuelve averageScore como null cuando el candidato no tiene entrevistas con score', async () => {
+        prismaMock.application.findMany.mockResolvedValue([
+            {
+                id: 1,
+                candidateId: 10,
+                currentInterviewStep: 3,
+                candidate: { id: 10, firstName: 'Juan', lastName: 'Pérez' },
+            },
+        ]);
+
+        // No hay entrevistas con score para el candidato
+        prismaMock.interview.findMany.mockResolvedValue([]);
+
+        await getCandidatesByPosition(req, res);
+
+        expect(res.json).toHaveBeenCalledWith([
+            {
+                applicationId: 1,
+                fullName: 'Juan Pérez',
+                currentInterviewStep: 3,
+                averageScore: null,
+            },
+        ]);
+    });
+    
+});

--- a/backend/api-spec.yaml
+++ b/backend/api-spec.yaml
@@ -185,4 +185,55 @@ paths:
           description: Invalid file type, only PDF and DOCX are allowed
         '500':
           description: Error during the file upload process
+  /positions/{id}/candidates:
+    get:
+      summary: Returns all applications for a given position, including the candidate's full name, the current interview step id, the application id, and the candidate's average interview score.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: Position ID
+      responses:
+        '200':
+          description: Returns an array of objects with the fields: applicationId, fullName, currentInterviewStep, averageScore.
+        '400':
+          description: Invalid position id.
+        '404':
+          description: No applications found for this position.
+
+  /candidates/{id}/stage:
+    put:
+      summary: Updates the current interview step of a candidate's application.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+          description: Candidate ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                applicationId:
+                  type: integer
+                  description: Application ID to update
+                currentInterviewStep:
+                  type: integer
+                  description: New interview step ID
+              required:
+                - applicationId
+                - currentInterviewStep
+      responses:
+        '200':
+          description: Stage updated successfully, returns a message and the updated application object.
+        '400':
+          description: Invalid candidate id, applicationId, currentInterviewStep, or Interview step does not exist.
+        '404':
+          description: Application not found for this candidate.
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import { PrismaClient } from '@prisma/client';
 import dotenv from 'dotenv';
 import candidateRoutes from './routes/candidateRoutes';
+import positionRoutes from './routes/positionRoutes';
 import { uploadFile } from './application/services/fileUploadService';
 import cors from 'cors';
 
@@ -38,6 +39,7 @@ app.use(cors({
 
 // Import and use candidateRoutes
 app.use('/candidates', candidateRoutes);
+app.use('/positions', positionRoutes);
 
 // Route for file uploads
 app.post('/upload', uploadFile);

--- a/backend/src/presentation/controllers/candidateController.ts
+++ b/backend/src/presentation/controllers/candidateController.ts
@@ -31,4 +31,48 @@ export const getCandidateById = async (req: Request, res: Response) => {
     }
 };
 
+export const updateApplicationStage = async (req: Request, res: Response) => {
+  const prisma = req.prisma;
+  const candidateId = parseInt(req.params.id);
+  const { applicationId, currentInterviewStep } = req.body;
+
+  if (isNaN(candidateId) || !applicationId || !currentInterviewStep) {
+    return res.status(400).json({ message: 'Invalid candidate id, applicationId o currentInterviewStep' });
+  }
+
+  try {
+    // Validar que la etapa exista
+    const step = await prisma.interviewStep.findUnique({
+      where: { id: currentInterviewStep },
+    });
+    if (!step) {
+      return res.status(400).json({ message: 'Interview step does not exist' });
+    }
+
+    // Buscar la aplicación del candidato
+    const application = await prisma.application.findFirst({
+      where: {
+        id: applicationId,
+        candidateId: candidateId,
+      },
+    });
+    if (!application) {
+      return res.status(404).json({ message: 'Application not found for this candidate' });
+    }
+
+    // Actualizar la etapa
+    const updated = await prisma.application.update({
+      where: { id: applicationId },
+      data: { currentInterviewStep },
+    });
+
+    return res.status(200).json({
+      message: 'Stage updated successfully',
+      application: updated,
+    });
+  } catch (error) {
+    return res.status(500).json({ message: 'Internal server error' });
+  }
+};
+
 export { addCandidate };

--- a/backend/src/presentation/controllers/positionController.ts
+++ b/backend/src/presentation/controllers/positionController.ts
@@ -1,0 +1,70 @@
+import { Request, Response } from 'express';
+
+export const getCandidatesByPosition = async (req: Request, res: Response) => {
+  const prisma = req.prisma;
+  const positionId = parseInt(req.params.id);
+
+  if (isNaN(positionId)) {
+    return res.status(400).json({ message: 'Invalid position id' });
+  }
+
+  // Buscar todas las aplicaciones para la posición, incluyendo candidato
+  const applications = await prisma.application.findMany({
+    where: { positionId },
+    include: {
+      candidate: {
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+        },
+      },
+    },
+  });
+
+  if (!applications || applications.length === 0) {
+    return res.status(404).json({ message: 'No applications found for this position' });
+  }
+
+  // Obtener todos los candidateIds únicos
+  const candidateIds = applications.map(app => app.candidateId);
+
+  // Buscar todas las entrevistas de estos candidatos
+  const interviews = await prisma.interview.findMany({
+    where: {
+      application: {
+        candidateId: { in: candidateIds },
+      },
+      score: { not: null },
+    },
+    select: {
+      application: { select: { candidateId: true } },
+      score: true,
+    },
+  });
+
+  // Calcular el promedio de score por candidato
+  const scoresByCandidate: Record<number, number[]> = {};
+  interviews.forEach(interview => {
+    const candidateId = interview.application.candidateId;
+    if (!scoresByCandidate[candidateId]) scoresByCandidate[candidateId] = [];
+    if (interview.score !== null) scoresByCandidate[candidateId].push(interview.score);
+  });
+
+  // Construir la respuesta
+  const result = applications.map(app => {
+    const scores = scoresByCandidate[app.candidateId] || [];
+    const averageScore = scores.length > 0
+      ? parseFloat((scores.reduce((a, b) => a + b, 0) / scores.length).toFixed(2))
+      : null;
+
+    return {
+      applicationId: app.id,
+      fullName: `${app.candidate.firstName} ${app.candidate.lastName}`,
+      currentInterviewStep: app.currentInterviewStep,
+      averageScore,
+    };
+  });
+
+  res.json(result);
+};

--- a/backend/src/routes/candidateRoutes.ts
+++ b/backend/src/routes/candidateRoutes.ts
@@ -1,5 +1,7 @@
 import { Router } from 'express';
 import { addCandidate, getCandidateById } from '../presentation/controllers/candidateController';
+import { updateApplicationStage } from '../presentation/controllers/candidateController';
+
 
 const router = Router();
 
@@ -18,5 +20,7 @@ router.post('/', async (req, res) => {
 });
 
 router.get('/:id', getCandidateById);
+
+router.put('/:id/stage', updateApplicationStage);
 
 export default router;

--- a/backend/src/routes/positionRoutes.ts
+++ b/backend/src/routes/positionRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getCandidatesByPosition } from '../presentation/controllers/positionController';
+
+const router = Router();
+
+router.get('/:id/candidates', getCandidatesByPosition);
+
+export default router;

--- a/prompts/prompts-JAPM.md
+++ b/prompts/prompts-JAPM.md
@@ -1,0 +1,179 @@
+# Implementación de requerimientos
+1. ¿me puedes dar los detalles del proyecto actual?
+2. ¿el proyecto tiene unidad de test?
+3. ¿De que manera podemos iniciar la ejecución del backend?
+4. Dame una lista de instrucciones para iniciar la ejecución del backen en modo desarrollo, considera que no tengo ningun contenedor de docker en ejecución, por lo que no hay una base de datos activa. Incluye los comandos a ejecutar de ser necesario. ¿Tienes alguna pregunta antes de comenzar?
+
+## Prompt 5
+Implementa un endpoint en un proyecto Node.js con TypeScript, Express y Prisma para el siguiente requerimiento:
+
+# Endpoint:
+GET /positions/:id/candidates
+
+# Funcionalidad:
+Devuelve todas las aplicaciones (applications) para una posición específica (positionId). Para cada aplicación, la respuesta debe incluir:
+
+- El nombre completo del candidato (concatenar firstName y lastName de la tabla Candidate)
+- El id del paso actual de entrevista (current_interview_step, campo currentInterviewStep de la tabla Application)
+- El id de la aplicación (id de la tabla Application)
+- La puntuación media del candidato, calculada usando todas las entrevistas (Interview) asociadas a ese candidato (no solo de esa aplicación), usando el campo score (ignorar entrevistas sin score)
+
+# Respuesta esperada (ejemplo):
+```json
+[
+  {
+    "applicationId": 1,
+    "fullName": "Juan Pérez",
+    "currentInterviewStep": 3,
+    "averageScore": 7.5
+  },
+  ...
+]
+```
+# Notas técnicas:
+- Utiliza Prisma Client para las consultas.
+- El endpoint debe estar en Express.
+- Si un candidato no tiene entrevistas con score, averageScore debe ser null.
+- No es necesario paginar ni filtrar más allá del positionId.
+
+# Estructura sugerida:
+- Crea el handler para el endpoint en un archivo de rutas Express.
+- Utiliza Prisma para obtener las aplicaciones de la posición, incluyendo los datos del candidato y calculando la media de scores de todas sus entrevistas.
+
+# Pautas para generar el contenido
+- Genera una lista de pasos para realizar la implementación
+- En cada paso de la lista menciona el archivo que se va a crear o modificar e incluye el código que se va agregar
+
+Antes de realizar la tarea revisa mis requerimientos ¿hay algo que me este faltando considerar?
+Hazme preguntas si necesitas más información.
+
+6. Antes de realizar las pruebas unitaras ayudame a probar manualmente el endpoint implementado ¿como lo hariamos?
+7. Al realizar la petición "curl http://localhost:3010/positions/1/candidates" obtengo el siguiente error: <detalles del error> ¿como lo arreglamos?
+
+## Prompt 8
+Implementa pruebas unitarias usando Jest para el endpoint GET /positions/:id/candidates definido en el controlador #file:positionController.ts 
+# Requisitos:
+
+- Mockea Prisma Client y los objetos Request/Response de Express.
+- Ubica el archivo de pruebas en la carpeta __tests__ en la raíz de la carpeta backend.
+- Cubre los siguientes casos:
+- Cuando existen aplicaciones para la posición, devuelve correctamente el array con los datos esperados (incluyendo el promedio de score).
+- Cuando no existen aplicaciones para la posición, devuelve un status 404 y el mensaje correspondiente.
+- Cuando el id de la posición no es válido (no numérico), devuelve un status 400 y el mensaje correspondiente.
+- Cuando existen aplicaciones pero el candidato no tiene entrevistas con score, el campo averageScore debe ser null.
+
+# Notas técnicas:
+
+- Mockea los métodos de Prisma (findMany) para devolver datos de prueba.
+- Mockea los métodos de Express (req, res) usando spies o funciones simuladas.
+- No es necesario levantar el servidor ni hacer peticiones HTTP reales.
+- Usa TypeScript en el archivo de pruebas.
+
+# Ejemplo de estructura esperada del archivo de pruebas:
+```typescript
+import { getCandidatesByPosition } from '../src/presentation/controllers/positionController';
+// ... mocks y tests aquí ...
+```
+
+# Pautas para generar el contenido
+- Genera una lista de pasos para realizar la implementación
+- Cada paso se va ejecutar de manera individual por lo que me tienes que preguntar si podemos pasar al siguiente
+- En cada paso de la lista menciona el archivo que se va a crear o modificar e incluye el código que se va agregar
+
+Antes de realizar la tarea revisa mis requisitos ¿hay algo que me este faltando considerar?
+Hazme preguntas si necesitas más información.
+
+9. Ayudame a ejecutar las pruebas
+
+
+
+# Refinación de prompts
+
+# Prompt 1
+Eres un experto en TypeScript, NodeJS, Express, Prisma y PostgreSQL.
+# Contexto inicial
+Tenemos una aplicación para gestionar candidatos y nos piden implementar nuevos endpoints en el backend pidiendos los siguiente: "Tu misión en este ejercicio es crear dos nuevos endpoints que nos permitirán manipular la lista de candidatos de una aplicación en una interfaz tipo kanban."
+
+# Instrucciones Generales
+El objetivo es crear un prompt para Copilot (CahtGPT 4.1) que implemente el siguiente requerimiento
+
+# Requerimientos
+"GET /positions/:id/candidates
+
+Este endpoint recogerá todos los candidatos en proceso para una determinada posición, es decir, todas las aplicaciones para un determinado positionID. Debe proporcionar la siguiente información básica:
+
+- Nombre completo del candidato (de la tabla candidate). current_interview_step: en qué fase del proceso está el candidato (de la tabla application).
+- La puntuación media del candidato. Recuerda que cada entrevist (interview) realizada por el candidato tiene un score"
+
+Antes de generar el prompt ¿tienes alguna pregunta?
+
+## Prompt 2
+
+Eres un experto en TypeScript, NodeJS, Express, Prisma y PostgreSQL.
+
+# Contexto inicial
+Tenemos una aplicación para gestionar candidatos y nos piden implementar nuevos endpoints en el backend pidiendos los siguiente: "Tu misión en este ejercicio es crear dos nuevos endpoints que nos permitirán manipular la lista de candidatos de una aplicación en una interfaz tipo kanban."
+
+# Instrucciones Generales
+El objetivo es crear un prompt para Copilot (CahtGPT 4.1) que implemente el siguiente requerimiento
+
+# Requerimientos
+"GET /positions/:id/candidates
+
+Este endpoint recogerá todos los candidatos en proceso para una determinada posición, es decir, todas las aplicaciones para un determinado positionID. Debe proporcionar la siguiente información básica:
+
+Nombre completo del candidato (de la tabla candidate). current_interview_step: en qué fase del proceso está el candidato (de la tabla application).
+La puntuación media del candidato. Recuerda que cada entrevist (interview) realizada por el candidato tiene un score"
+
+Antes de generar el prompt ¿tienes alguna pregunta?
+
+## Prompt 3
+# Contexto inicial
+Queremos implementar pruebas unitarias para el endpoint "GET /positions/:id/candidates"
+
+# Instrucciones Generales
+El objetivo es crear un prompt para Copilot (ChatGPT 4.1) que implemente las pruebas unitarias.
+
+Antes de generar el prompt ¿tienes alguna pregunta?
+
+## Prompt 4
+Eres un experto en TypeScript, NodeJS, Express, Prisma y PostgreSQL.
+
+# Contexto inicial
+Tenemos una aplicación para gestionar candidatos y nos piden implementar nuevos endpoints en el backend pidiendos los siguiente: "Tu misión en este ejercicio es crear dos nuevos endpoints que nos permitirán manipular la lista de candidatos de una aplicación en una interfaz tipo kanban."
+
+# Instrucciones Generales
+El objetivo es crear un prompt para Copilot (CahtGPT 4.1) que implemente el siguiente requerimiento
+
+# Requerimientos
+"PUT /candidates/:id/stage
+
+Este endpoint actualizará la etapa del candidato movido. Permite modificar la fase actual del proceso de entrevista en la que se encuentra un candidato específico."
+Antes de generar el prompt ¿tienes alguna pregunta?
+
+## Prompt 5
+# Contexto inicial
+Queremos implementar pruebas unitarias para el endpoint "PUT /candidates/:id/stage"
+
+# Instrucciones Generales
+El objetivo es crear un prompt para Copilot (CahtGPT 4.1) que implemente las pruebas unitarias.
+
+Antes de generar el prompt ¿tienes alguna pregunta?
+
+## Prompt 6
+Eres un experto en documentación de APIs en formato YAML, así como en generación de Prompts
+
+# Contexto inicial
+Tenemos una aplicación para gestionar candidatos y nos piden implementar nuevos endpoints en el backend pidiendos los siguiente: "Tu misión en este ejercicio es crear dos nuevos endpoints que nos permitirán manipular la lista de candidatos de una aplicación en una interfaz tipo kanban."
+Los endpoints de los metodos "GET /positions/:id/candidates" y "PUT /candidates/:id/stage" ya estan implementados, lo que requerimos ahora es actualizar la documentación.
+
+# Instrucciones Generales
+El objetivo es crear un prompt para Copilot (CahtGPT 4.1) que actualice la documentación de archivo #file:api-spec.yaml
+
+Antes de generar el prompt ¿hay algo que me este faltando considerar?
+Hazme preguntas si necesitas más información.
+
+# Ejecución de seed.ts
+
+1. Vamos a generar datos de prueba para el proyecto, los necesitamos para probar un endpoint ¿que necesitmos realizar para ejecutar #file:seed.ts?
+Considera que ya tengo una base de datos en ejecución y lista para ser consumida.


### PR DESCRIPTION
# Resumen de Cambios Técnicos y Resolución de Problemas

## Cambios Técnicos Realizados

### 1. Implementación de Endpoints

- **GET /positions/:id/candidates**
  - Nuevo endpoint en Express para obtener todas las aplicaciones de una posición, incluyendo:
    - Nombre completo del candidato
    - Id del paso actual de entrevista
    - Id de la aplicación
    - Puntuación media del candidato en entrevistas
  - Lógica implementada en un nuevo archivo de rutas `positionRoutes.ts` y controlador correspondiente.
  - Uso de Prisma Client para consultas y agregaciones.

- **PUT /candidates/:id/stage**
  - Nuevo endpoint para actualizar el paso de entrevista (`currentInterviewStep`) de una aplicación específica de un candidato.
  - El body incluye `applicationId` y `currentInterviewStep`.
  - Validación de existencia de la etapa y de la aplicación antes de actualizar.
  - Lógica implementada en el controlador de candidatos.

### 2. Pruebas Unitarias

- Se crearon archivos de pruebas en `backend/__tests__` para ambos endpoints usando Jest.
- Mock de Prisma Client y objetos Request/Response de Express.
- Casos cubiertos:
  - Respuestas exitosas
  - Validaciones de errores (400, 404)
  - Manejo de errores inesperados (500)
  - Casos especiales como promedio nulo o actualización redundante

### 3. Documentación OpenAPI

- Se actualizó el archivo `api-spec.yaml` para documentar ambos endpoints, sus parámetros, request body y posibles respuestas.
- Se siguieron las convenciones solicitadas (sin ejemplos, solo códigos de error y descripciones en inglés).

### 4. Otros Cambios

- Se aseguró el uso de `express.json()` como middleware para parsear JSON en las peticiones.
- Se revisó y adaptó el seed de la base de datos para pruebas manuales.

---

## Problemas Encontrados y Soluciones

### 1. Error al incluir campos escalares en `include` de Prisma
- **Problema:** Prisma arrojó error al intentar incluir un campo escalar (`currentInterviewStep`) en el bloque `include`.
- **Solución:** Se eliminó el campo del bloque `include` y se accedió directamente al valor retornado por Prisma.

### 2. Problemas con el formato de JSON en peticiones curl en Windows
- **Problema:** El uso de comillas simples en el body de curl causó errores de parseo y de puerto.
- **Solución:** Se recomendó usar comillas dobles escapadas para el body en Windows, o usar Postman/Insomnia.

### 3. Ambigüedad sobre la "aplicación activa" de un candidato
- **Problema:** Un candidato puede tener varias aplicaciones; se necesitaba especificar cuál actualizar.
- **Solución:** Se decidió que el `applicationId` se enviaría explícitamente en el body de la petición.

### 4. Validación de ids y manejo de errores
- **Problema:** Necesidad de validar correctamente los ids y responder con los códigos y mensajes adecuados.
- **Solución:** Se implementaron validaciones explícitas y respuestas siguiendo la convención OpenAPI.

---

## Refinación de Prompts

Durante el desarrollo, se generaron y refinaron múltiples prompts para guiar la implementación y pruebas de los endpoints, así como la documentación y la generación de datos de prueba.  
Estos prompts cubren:

- Solicitud de detalles del proyecto y su configuración.
- Instrucciones para pruebas unitarias y manuales.
- Prompts para la implementación de endpoints específicos.
- Prompts para la actualización de la documentación OpenAPI.
- Prompts para la ejecución de scripts de seed y generación de datos de prueba.
- Preguntas de refinamiento para asegurar claridad en los requerimientos antes de cada implementación.

Estos prompts están documentados en el archivo `prompts/prompts-JAPM.md` y pueden ser reutilizados o adaptados para futuras tareas de desarrollo y documentación en el